### PR TITLE
Fix Caching by removing page caching of "/"

### DIFF
--- a/assets/event_sources.json
+++ b/assets/event_sources.json
@@ -152,13 +152,6 @@
 			"city": "Oakland",
 			"prefixTitle": "📽️",
 			"suffixDescription": "<br /><a href=\"https://www.instagram.com/newhabitcinema/\">Instagram</a>"
-		},
-		{
-			"name": "Testing Calendar MROW MROW MROW MROW",
-			"googleCalendarId": "91970fbecb72d7873ee993a82b77fc2966bebbade86241bcfa62f9aa4c29fae1@group.calendar.google.com",
-			"city": "Oakland",
-			"prefixTitle": "🇨🇳:ripple:",
-			"suffixDescription": "<br />MROW MROW MROW MROW MROW MROW MROW MROW MROW MRORMWOW MROW"
 		}
 	],
 	"squarespace": [

--- a/assets/event_sources.json
+++ b/assets/event_sources.json
@@ -152,6 +152,13 @@
 			"city": "Oakland",
 			"prefixTitle": "📽️",
 			"suffixDescription": "<br /><a href=\"https://www.instagram.com/newhabitcinema/\">Instagram</a>"
+		},
+		{
+			"name": "Testing Calendar MROW MROW MROW MROW",
+			"googleCalendarId": "91970fbecb72d7873ee993a82b77fc2966bebbade86241bcfa62f9aa4c29fae1@group.calendar.google.com",
+			"city": "Oakland",
+			"prefixTitle": "🇨🇳:ripple:",
+			"suffixDescription": "<br />MROW MROW MROW MROW MROW MROW MROW MROW MROW MRORMWOW MROW"
 		}
 	],
 	"squarespace": [

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -44,15 +44,4 @@ export default defineNuxtConfig({
   },
   plugins: [{ src: "~/plugins/vercel.ts", mode: "client" }],
   css: ["vue-final-modal/style.css"],
-  nitro: {
-    routeRules: {
-      "/": {
-        cache: {
-          swr: true,
-          maxAge: serverCacheMaxAgeSeconds,
-          staleMaxAge: serverStaleWhileInvalidateSeconds,
-        },
-      },
-    },
-  },
 });

--- a/utils/util.ts
+++ b/utils/util.ts
@@ -1,21 +1,3 @@
-
-// The Event object is based on https://fullcalendar.io/docs/event-object, as well as 
-interface Event {
-	title: string | null;
-	start: Date | null;
-	end: Date | null;
-	url: string;
-	display?: string;
-	backgroundColor?: string;
-	borderColor?: string;
-	textColor?: string;
-	classNames?: string[];
-	extendedProps?: Object;
-}
-
-
-export const toCorsProxy = (url: string) => 'https://corsproxy.io/?' + encodeURIComponent(url);
-
 export const clientCacheMaxAgeSeconds = 20 * 60;
 export const clientStaleWhileInvalidateSeconds = 12 * 3600;
 

--- a/utils/util.ts
+++ b/utils/util.ts
@@ -1,8 +1,3 @@
-interface EventNormalSource {
-	events: Event[];
-	city: string;
-	display?: string;
-}
 
 // The Event object is based on https://fullcalendar.io/docs/event-object, as well as 
 interface Event {
@@ -18,16 +13,13 @@ interface Event {
 	extendedProps?: Object;
 }
 
-interface EventGoogleCalendarSource {
-	googleCalendarId: string;
-}
 
 export const toCorsProxy = (url: string) => 'https://corsproxy.io/?' + encodeURIComponent(url);
 
-export const clientCacheMaxAgeSeconds = 4 * 3600;
+export const clientCacheMaxAgeSeconds = 20 * 60;
 export const clientStaleWhileInvalidateSeconds = 12 * 3600;
 
-export const serverCacheMaxAgeSeconds = 4 * 3600;
+export const serverCacheMaxAgeSeconds = 20 * 60;
 // For how long can a server use an invalidated response (during which it will revalidate for the next request).
 // But it appears that the Nitro server (Nuxt's backend) supports a specific flag for always using stale-while-revalidating if set to -1.
 // https://nitro.unjs.io/guide/introduction/cache
@@ -48,7 +40,6 @@ export const eventDayDurationSplitThreshold = 3;
 import { badgeMap } from '../server/badgeMap';
 import DOMPurify from 'dompurify';
 export const replaceBadgePlaceholders = (text: string): string => {
-	const sanitizedText = DOMPurify.sanitize(text);
 	return text.replace(/:\w+:/g, (match) => badgeMap[match] || match);
   };
   


### PR DESCRIPTION
Previously caching would be unreliable, but this is because both the API calls AND the webpage at the root directory were being cached. I've taken the liberty to reduce the caching time to 20 minutes as well, so changes should appear much more quickly. This may finally be the solution!!!

Thanks to @DanielKim1 for his extensive work in helping me understanding caching in Nuxt's backend, Nitro, last night. Couldn't have done this without you!