### PR TITLE
Experiment with caching rules

### DIFF
--- a/components/App.vue
+++ b/components/App.vue
@@ -11,7 +11,6 @@ import FullCalendar from '@fullcalendar/vue3'
 import { ModalsContainer, useModal } from 'vue-final-modal'
 import FilterModal from './FilterModal.vue'
 import EventModal from './EventModal.vue'
-import { clientCacheMaxAgeSeconds, clientStaleWhileInvalidateSeconds } from '~~/utils/util';
 import { replaceBadgePlaceholders } from '~~/utils/util';
 
 const clickedEvent = ref(null); // For storing the clickedEvent data
@@ -344,12 +343,9 @@ async function getEventSources() {
     '/api/events/wix',
     */
   ];
-  const clientHeaders = {
-    'Cache-Control': `max-age=${clientCacheMaxAgeSeconds}, stale-while-revalidate=${clientStaleWhileInvalidateSeconds}`,
-  };
   // This is to preventing the UI changes from each fetch result to cause more fetches to occur.,
   Promise.allSettled(endpoints.map(async (endpoint) => {
-    const { data: response } = await useLazyFetch(endpoint, { headers: clientHeaders });
+    const { data: response } = await useLazyFetch(endpoint);
     return addEventSources(transformEventSourcesResponse(response));
   }));
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,8 +1,3 @@
-import {
-  serverCacheMaxAgeSeconds,
-  serverStaleWhileInvalidateSeconds,
-} from "./utils/util";
-
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   typescript: {
@@ -44,4 +39,10 @@ export default defineNuxtConfig({
   },
   plugins: [{ src: "~/plugins/vercel.ts", mode: "client" }],
   css: ["vue-final-modal/style.css"],
+  routeRules: {
+    "/": { isr: true },
+    "/api/**": { cors: true, isr: 60 },
+    "/contributing": { isr: true },
+    "/list": { isr: true },
+  },
 });

--- a/server/api/events/elfsight.ts
+++ b/server/api/events/elfsight.ts
@@ -1,19 +1,14 @@
 import eventSourcesJSON from '@/assets/event_sources.json';
-import { logTimeElapsedSince, serverCacheMaxAgeSeconds, serverStaleWhileInvalidateSeconds, serverFetchHeaders } from '@/utils/util';
-import { url } from 'inspector';
+import { logTimeElapsedSince } from '@/utils/util';
 import { DateTime } from 'luxon';
 
-export default defineCachedEventHandler(async (event) => {
+export default defineEventHandler(async () => {
 	const startTime = new Date();
 	const body = await fetchElfsightEvents();
 	logTimeElapsedSince(startTime.getTime(), 'Elfsight: events fetched.');
 	return {
 		body
 	}
-}, {
-	maxAge: serverCacheMaxAgeSeconds,
-	staleMaxAge: serverStaleWhileInvalidateSeconds,
-	swr: true,
 });
 
 function formatTitleAndDateToID(inputDate: any, title: string) {
@@ -52,7 +47,7 @@ async function fetchElfsightEvents() {
 		elfsightSources = await Promise.all(
 			eventSourcesJSON.elfsight.map(async (source) => {
 				// Add current date in milliseconds to the URL to get events starting from this moment.
-				const response = await fetch(source.url, { headers: serverFetchHeaders });
+				const response = await fetch(source.url);
 				if (!response.ok) {
 					console.error('[Elfsight] Error: could not fetch events from', source.url);
 					return {

--- a/server/api/events/google-calendar.ts
+++ b/server/api/events/google-calendar.ts
@@ -1,7 +1,7 @@
 import eventSourcesJSON from '@/assets/event_sources.json';
-import { logTimeElapsedSince, serverCacheMaxAgeSeconds, serverStaleWhileInvalidateSeconds, serverFetchHeaders } from '@/utils/util';
+import { logTimeElapsedSince } from '@/utils/util';
 
-export default defineCachedEventHandler(async (event) => {
+export default defineEventHandler(async () => {
 	// export default defineEventHandler(async (event) => {
 	const startTime = new Date();
 	const body = await fetchGoogleCalendarEvents();
@@ -9,10 +9,6 @@ export default defineCachedEventHandler(async (event) => {
 	return {
 		body
 	}
-}, {
-	maxAge: serverCacheMaxAgeSeconds,
-	staleMaxAge: serverStaleWhileInvalidateSeconds,
-	swr: true,
 });
 
 // Function to replace Google tracking URLs with the actual URL
@@ -79,8 +75,7 @@ function formatTitleAndDateToID(inputDate: any, title: string) {
   
 		  const res = await fetch(
 			`https://www.googleapis.com/calendar/v3/calendars/${source.googleCalendarId}/events?key=${process.env.GOOGLE_CALENDAR_API_KEY}`
-			+ `&${searchParams.toString()}`,
-			{ headers: serverFetchHeaders }
+			+ `&${searchParams.toString()}`
 		  );
 		  
 		  if (!res.ok) {

--- a/server/api/events/squarespace.ts
+++ b/server/api/events/squarespace.ts
@@ -1,19 +1,14 @@
 import eventSourcesJSON from '@/assets/event_sources.json';
-import { logTimeElapsedSince, serverCacheMaxAgeSeconds, serverStaleWhileInvalidateSeconds, serverFetchHeaders } from '@/utils/util';
-import { url } from 'inspector';
+import { logTimeElapsedSince } from '@/utils/util';
 import { DateTime } from 'luxon';
 
-export default defineCachedEventHandler(async (event) => {
+export default defineEventHandler(async () => {
 	const startTime = new Date();
 	const body = await fetchSquarespaceEvents();
 	logTimeElapsedSince(startTime.getTime(), 'Squarespace: events fetched.');
 	return {
 		body
 	}
-}, {
-	maxAge: serverCacheMaxAgeSeconds,
-	staleMaxAge: serverStaleWhileInvalidateSeconds,
-	swr: true,
 });
 
 function formatTitleAndDateToID(inputDate: any, title: string) {
@@ -52,7 +47,7 @@ async function fetchSquarespaceEvents() {
 		squarespaceSources = await Promise.all(
 			eventSourcesJSON.squarespace.map(async (source) => {
 				// Add current date in milliseconds to the URL to get events starting from this moment.
-				const response = await fetch(source.url, { headers: serverFetchHeaders });
+				const response = await fetch(source.url);
 				if (!response.ok) {
 					console.error('[Squarespace] Error: could not fetch events from', source.url);
 					return {

--- a/server/api/fetchImage.ts
+++ b/server/api/fetchImage.ts
@@ -1,7 +1,6 @@
-import { H3Event } from "h3";
 import axios from "axios";
 
-export default eventHandler(async (event: H3Event) => {
+export default defineEventHandler(async (event) => {
   const { url } = getQuery(event);
 
   if (typeof url !== "string") {
@@ -36,9 +35,6 @@ export default eventHandler(async (event: H3Event) => {
 
   // Set appropriate headers and return an image response
   setHeader(event, "content-type", type);
-
-  // Add caching headers
-  setHeader(event, "Cache-Control", "public, max-age=31536000, immutable"); // Cache for a year and don't revalidate
 
   return Buffer.from(response.data, "binary");
 });

--- a/utils/util.ts
+++ b/utils/util.ts
@@ -1,6 +1,3 @@
-export const clientCacheMaxAgeSeconds = 20 * 60;
-export const clientStaleWhileInvalidateSeconds = 12 * 3600;
-
 export const serverCacheMaxAgeSeconds = 20 * 60;
 // For how long can a server use an invalidated response (during which it will revalidate for the next request).
 // But it appears that the Nitro server (Nuxt's backend) supports a specific flag for always using stale-while-revalidating if set to -1.
@@ -20,7 +17,6 @@ export const eventDayDurationSplitThreshold = 3;
 
 //Badge stuff
 import { badgeMap } from '../server/badgeMap';
-import DOMPurify from 'dompurify';
 export const replaceBadgePlaceholders = (text: string): string => {
 	return text.replace(/:\w+:/g, (match) => badgeMap[match] || match);
   };


### PR DESCRIPTION
Previously, we arrived at the conclusion that the issues we were facing with cache invalidation was due to our configuration being set to cache both the homepage and the API routes. However, now I suspect that maybe the issue was that our API routes were being double-cached: once at the Nuxt configuration level, and again with the manually set headers.

This is an experimental PR for removing the manually set headers and caching the homepage again. This should allow better performance while keeping the cache invalidation working correctly.

Since the cache max age has been set to `60`, we should know if this PR works if the deployment off this branch caches events for one minute.